### PR TITLE
Heap Overflow in `rt_copy_memory`

### DIFF
--- a/dev/kernel/src/Utils.cc
+++ b/dev/kernel/src/Utils.cc
@@ -80,8 +80,6 @@ Int rt_copy_memory(const voidPtr src, voidPtr dst, Size len) {
     ++index;
   }
 
-  dstChar[index] = 0;
-
   return index;
 }
 


### PR DESCRIPTION
This patch removes a 1-byte heap overflow in `rt_copy_memory`, which unconditionally wrote a null terminator at `dst[len]`. When `len` equals the size of the destination buffer (256 bytes), that extra `'\0'` write overruns the buffer by one byte.

## Impact

- **Affected function:** `rt_copy_memory`
- **Trigger:** Any caller that passes a buffer of exactly `len` bytes (file creation with a 256-byte name).
- **Consequences:** Heap metadata corruption, undefined behavior, potential kernel crash or privesc for that matter.
- **CWE:** [CWE-122: Heap-based Buffer Overflow](https://cwe.mitre.org/data/definitions/122.html)

## Patch

To avoid breaking existing callers or changing the public API, this patch takes a minimal approach: it simply removes the overflow-causing line without adding bounds checks or altering the function signature.

```diff
--- a/dev/kernel/src/Utils.cc
+++ b/dev/kernel/src/Utils.cc
@@ -1,15 +1,12 @@
 Int rt_copy_memory(const voidPtr src, voidPtr dst, Size len) {
-  char* srcChr  = reinterpret_cast<char*>(src);
-  char* dstChar = reinterpret_cast<char*>(dst);
-  Size  index   = 0;
+  char* srcChr  = reinterpret_cast<char*>(src);
+  char* dstChar = reinterpret_cast<char*>(dst);
+  Size  index   = 0;

   while (index < len) {
     dstChar[index] = srcChr[index];
     ++index;
   }

-  dstChar[index] = 0; // 1-byte overflow
-
   return index;
 }
```

> If any call site assumes the destination will be null-terminated, that logic should now be handled explicitly by the caller and only if there is space.

## Notes

This issue is reachable via `NeFileSystemParser::CreateCatalog` → `rt_copy_memory(..., child_catalog->Name, rt_string_len(name))` and affects heap-allocated file metadata structures.