### PR TITLE
Unsafe mem-op in mkfs.hefs.

### DIFF
--- a/tooling/mkfs.hefs.cc
+++ b/tooling/mkfs.hefs.cc
@@ -55,9 +55,10 @@ static std::string build_args(int argc, char** argv) {
 int main(int argc, char** argv) {
     if (argc < 2) {
         mkfs::console_out()
-            << "hefs: usage: mkfs.hefs -L <label> -s <sector_size> -b <ind_start> -e <ind_end> "
-               "-bs <block_start> -be <block_end> -is <in_start> -ie <in_end> "
-               "-S <disk_size_GB> -o <output_device>\n";
+            << "hefs: usage: mkfs.hefs -L=<label> -s=<sector_size> -b=<ind_start> -e=<ind_end> "
+               "-bs=<block_start> -be=<block_end> -is=<in_start> -ie=<in_end> "
+               "-S=<disk_size_GB> -o=<output_device>\n";
+
         return EXIT_FAILURE;
     }
 

--- a/tooling/mkfs.hefs.cc
+++ b/tooling/mkfs.hefs.cc
@@ -7,123 +7,226 @@
 #include <tooling/hefs.h>
 #include <tooling/mkfs.h>
 #include <cstdlib>
+#include <cstring>
 #include <fstream>
+#include <limits>
+#include <algorithm>
 
 namespace detail {
-/// @interal
-/// @brief GB equation formula.
+/// @internal
+/// @brief GB‐to‐byte conversion (use multiplication, not XOR).
 static constexpr size_t gib_cast(uint32_t gb) {
-  return ((1024 ^ 3) * gb);
+    return static_cast<size_t>(gb) * 1024ULL * 1024ULL * 1024ULL;
 }
 }  // namespace detail
 
 static size_t        kDiskSize   = detail::gib_cast(4UL);
 static uint16_t      kVersion    = kHeFSVersion;
-static std::u8string kLabel      = kHeFSDefaultVolumeName;
+static std::u8string kLabel;             
 static size_t        kSectorSize = 512;
 
-/// @brief Entrypoint of tool.
+static bool parse_decimal(const std::string& opt, unsigned long long& out) {
+    if (opt.empty()) return false;
+    char* endptr = nullptr;
+    unsigned long long val = std::strtoull(opt.c_str(), &endptr, 10);
+    if (endptr == opt.c_str() || *endptr != '\0') return false;
+    out = val;
+    return true;
+}
+
+static bool parse_signed(const std::string& opt, long& out, int base = 10) {
+    if (opt.empty()) return false;
+    char* endptr = nullptr;
+    long val = std::strtol(opt.c_str(), &endptr, base);
+    if (endptr == opt.c_str() || *endptr != '\0' || val < 0) return false;
+    out = val;
+    return true;
+}
+
+static std::string build_args(int argc, char** argv) {
+    std::string combined;
+    for (int i = 1; i < argc; ++i) {
+        combined += argv[i];
+        combined += ' ';
+    }
+    return combined;
+}
+
 int main(int argc, char** argv) {
-  if (argc < 2) {
-    mkfs::console_out()
-        << "hefs: usage: mkfs.hefs -L <label> -s <sector_size> -b <ind_start> -e "
-        << "<ind_end> -bs <block_start> -be <block_end> -is <in_start> -ie <in_end> "
-           "-S <disk_size> -o <output_device>"
-        << "\n";
-    return EXIT_FAILURE;
-  }
-
-  std::string   args;
-  std::u8string args_wide;
-
-  for (int i = 1; i < argc; ++i) {
-    args += argv[i];
-    args += " ";
-
-    std::string str = argv[i];
-
-    for (auto& ch : str) {
-      args_wide.push_back(ch);
+    if (argc < 2) {
+        mkfs::console_out()
+            << "hefs: usage: mkfs.hefs -L <label> -s <sector_size> -b <ind_start> -e <ind_end> "
+               "-bs <block_start> -be <block_end> -is <in_start> -ie <in_end> "
+               "-S <disk_size_GB> -o <output_device>\n";
+        return EXIT_FAILURE;
     }
 
-    args_wide += u8" ";
-  }
+    std::string args = build_args(argc, argv);
 
-  auto output_path = mkfs::get_option<char>(args, "-o");
+    auto output_path = mkfs::get_option<char>(args, "-o");
+    if (output_path.empty()) {
+        mkfs::console_out() << "hefs: error: Missing -o <output_device> argument.\n";
+        return EXIT_FAILURE;
+    }
 
-  kSectorSize = std::strtol(mkfs::get_option<char>(args, "-s").data(), nullptr, 10);
-  kLabel      = mkfs::get_option<char8_t>(args_wide, u8"-L");
+    auto opt_s = mkfs::get_option<char>(args, "-s");
+    long parsed_s = 0;
+    if (!parse_signed(opt_s, parsed_s, 10) || parsed_s == 0) {
+        mkfs::console_out()
+            << "hefs: error: Invalid sector size \"" << opt_s
+            << "\". Must be a positive integer.\n";
+        return EXIT_FAILURE;
+    }
 
-  if (!kSectorSize) {
-    mkfs::console_out() << "hefs: error: Sector size size is set to zero.\n";
-    return EXIT_FAILURE;
-  }
+    if ((parsed_s & (parsed_s - 1)) != 0) {
+        mkfs::console_out()
+            << "hefs: error: Sector size \"" << parsed_s
+            << "\" is not a power of two.\n";
+        return EXIT_FAILURE;
+    }
+    kSectorSize = static_cast<size_t>(parsed_s);
 
-  if (kLabel.empty()) kLabel = kHeFSDefaultVolumeName;
+    auto opt_L = mkfs::get_option<char>(args, "-L");
+    if (!opt_L.empty()) {
+        kLabel.clear();
+        for (char c : opt_L) kLabel.push_back(static_cast<char8_t>(c));
+    } else {
+        kLabel.clear();
+        for (size_t i = 0; i < kHeFSPartNameLen && kHeFSDefaultVolumeName[i] != u'\0'; ++i) {
+            kLabel.push_back(static_cast<char8_t>(kHeFSDefaultVolumeName[i]));
+        }
+    }
 
-  kDiskSize =
-      std::strtol(mkfs::get_option<char>(args, "-S").data(), nullptr, 10) * 1024 * 1024 * 1024;
+    auto opt_S = mkfs::get_option<char>(args, "-S");
+    unsigned long long gb = 0;
+    if (!parse_decimal(opt_S, gb) || gb == 0ULL) {
+        mkfs::console_out()
+            << "hefs: error: Invalid disk size \"" << opt_S
+            << "\". Must be a positive integer.\n";
+        return EXIT_FAILURE;
+    }
+    unsigned long long max_gb =
+        std::numeric_limits<uint64_t>::max() / (1024ULL * 1024ULL * 1024ULL);
+    if (gb > max_gb) {
+        mkfs::console_out()
+            << "hefs: error: Disk size \"" << gb << "GB\" is too large.\n";
+        return EXIT_FAILURE;
+    }
+    kDiskSize = static_cast<size_t>(gb * 1024ULL * 1024ULL * 1024ULL);
 
-  if (!kDiskSize) {
-    mkfs::console_out() << "hefs: error: Disk size is set to zero.\n";
-    return EXIT_FAILURE;
-  }
+    auto opt_b  = mkfs::get_option<char>(args, "-b");
+    auto opt_e  = mkfs::get_option<char>(args, "-e");
+    auto opt_bs = mkfs::get_option<char>(args, "-bs");
+    auto opt_be = mkfs::get_option<char>(args, "-be");
+    auto opt_is = mkfs::get_option<char>(args, "-is");
+    auto opt_ie = mkfs::get_option<char>(args, "-ie");
 
-  // Open the output_device
-  std::ofstream output_device(output_path, std::ios::binary);
+    long start_ind   = 0, end_ind    = 0;
+    long start_block = 0, end_block  = 0;
+    long start_in    = 0, end_in     = 0;
 
-  if (!output_device.good()) {
-    mkfs::console_out() << "hefs: error: Unable to open output_device: " << output_path << "\n";
-    return EXIT_FAILURE;
-  }
+    if (!parse_signed(opt_b, start_ind, 16)) {
+        mkfs::console_out() << "hefs: error: Invalid -b <hex> argument.\n";
+        return EXIT_FAILURE;
+    }
+    if (!parse_signed(opt_e, end_ind, 16) || end_ind <= start_ind) {
+        mkfs::console_out()
+            << "hefs: error: Invalid or out-of-range -e <hex> argument.\n";
+        return EXIT_FAILURE;
+    }
+    if (!parse_signed(opt_bs, start_block, 16)) {
+        mkfs::console_out() << "hefs: error: Invalid -bs <hex> argument.\n";
+        return EXIT_FAILURE;
+    }
+    if (!parse_signed(opt_be, end_block, 16) || end_block <= start_block) {
+        mkfs::console_out()
+            << "hefs: error: Invalid or out-of-range -be <hex> argument.\n";
+        return EXIT_FAILURE;
+    }
+    if (!parse_signed(opt_is, start_in, 16)) {
+        mkfs::console_out() << "hefs: error: Invalid -is <hex> argument.\n";
+        return EXIT_FAILURE;
+    }
+    if (!parse_signed(opt_ie, end_in, 16) || end_in <= start_in) {
+        mkfs::console_out()
+            << "hefs: error: Invalid or out-of-range -ie <hex> argument.\n";
+        return EXIT_FAILURE;
+    }
 
-  // create a boot node, and then allocate a index node directory tree.
-  mkfs::hefs::BootNode boot_node{{}, {}, 0, 0, 0, 0, 0, 0, 0, 0};
+    if (static_cast<size_t>(end_block) * kSectorSize > kDiskSize ||
+        static_cast<size_t>(end_ind)           > kDiskSize ||
+        static_cast<size_t>(end_in)            > kDiskSize) {
+        mkfs::console_out() << "hefs: error: One or more ranges exceed disk size.\n";
+        return EXIT_FAILURE;
+    }
 
-  auto start_ind = std::strtol(mkfs::get_option<char>(args, "-b").data(), nullptr, 16);
+    std::ofstream output_device(output_path, std::ios::binary);
+    if (!output_device.good()) {
+        mkfs::console_out()
+            << "hefs: error: Unable to open output device: " << output_path << "\n";
+        return EXIT_FAILURE;
+    }
 
-  start_ind += sizeof(mkfs::hefs::BootNode);
+    mkfs::hefs::BootNode boot_node;
+    std::memset(&boot_node, 0, sizeof(boot_node));
 
-  auto end_ind = std::strtol(mkfs::get_option<char>(args, "-e").data(), nullptr, 16);
+    boot_node.version    = kVersion;
+    boot_node.diskKind   = mkfs::hefs::kHeFSHardDrive;
+    boot_node.encoding   = mkfs::hefs::kHeFSEncodingFlagsUTF8;
+    boot_node.diskSize   = kDiskSize;
+    boot_node.sectorSize = kSectorSize;
+    boot_node.startIND   = static_cast<size_t>(start_ind) + sizeof(mkfs::hefs::BootNode);
+    boot_node.endIND     = static_cast<size_t>(end_ind);
+    boot_node.startIN    = static_cast<size_t>(start_in);
+    boot_node.endIN      = static_cast<size_t>(end_in);
+    boot_node.startBlock = static_cast<size_t>(start_block);
+    boot_node.endBlock   = static_cast<size_t>(end_block);
+    boot_node.indCount   = 0UL;
+    boot_node.diskStatus = mkfs::hefs::kHeFSStatusUnlocked;
 
-  auto start_block = std::strtol(mkfs::get_option<char>(args, "-bs").data(), nullptr, 16);
-  auto end_block   = std::strtol(mkfs::get_option<char>(args, "-be").data(), nullptr, 16);
+    static_assert(sizeof(boot_node.magic) >= kHeFSMagicLen,
+                  "BootNode::magic too small to hold kHeFSMagicLen");
+    std::memset(boot_node.magic, 0, sizeof(boot_node.magic));
+    size_t magic_copy =
+        (sizeof(boot_node.magic) < kHeFSMagicLen - 1)
+            ? sizeof(boot_node.magic)
+            : (kHeFSMagicLen - 1);
+    std::memcpy(boot_node.magic, kHeFSMagic, magic_copy);
+    boot_node.magic[magic_copy] = 0;
 
-  auto start_in = std::strtol(mkfs::get_option<char>(args, "-is").data(), nullptr, 16);
-  auto end_in   = std::strtol(mkfs::get_option<char>(args, "-ie").data(), nullptr, 16);
+    constexpr size_t vol_slots = kHeFSPartNameLen;
+    std::memset(boot_node.volumeName, 0, sizeof(boot_node.volumeName));
+    size_t label_units = std::min(kLabel.size(), vol_slots - 1);
+    for (size_t i = 0; i < label_units; ++i) {
+        boot_node.volumeName[i] = static_cast<char16_t>(kLabel[i]);
+    }
+    boot_node.volumeName[label_units] = 0;
 
-  boot_node.version    = kVersion;
-  boot_node.diskKind   = mkfs::hefs::kHeFSHardDrive;
-  boot_node.encoding   = mkfs::hefs::kHeFSEncodingFlagsUTF8;
-  boot_node.diskSize   = kDiskSize;
-  boot_node.sectorSize = kSectorSize;
-  boot_node.startIND   = start_ind;
-  boot_node.endIND     = end_ind;
-  boot_node.startIN    = start_in;
-  boot_node.endIN      = end_in;
-  boot_node.startBlock = start_block;
-  boot_node.endBlock   = end_block;
-  boot_node.indCount   = 0UL;
-  boot_node.diskStatus = mkfs::hefs::kHeFSStatusUnlocked;
+    output_device.seekp(static_cast<std::streamoff>(start_ind));
+    if (!output_device.good()) {
+        mkfs::console_out() << "hefs: error: Failed seek to index start.\n";
+        return EXIT_FAILURE;
+    }
 
-  std::memcpy(boot_node.magic, kHeFSMagic, kHeFSMagicLen - 1);
-  std::memcpy(boot_node.volumeName, kLabel.data(), kLabel.size() * sizeof(char16_t));
+    output_device.write(reinterpret_cast<const char*>(&boot_node),
+                        sizeof(boot_node));
+    if (!output_device.good()) {
+        mkfs::console_out()
+            << "hefs: error: Unable to write BootNode to output device: "
+            << output_path << "\n";
+        return EXIT_FAILURE;
+    }
 
-  output_device.seekp(std::strtol(mkfs::get_option<char>(args, "-b").data(), nullptr, 16));
-  output_device.write(reinterpret_cast<const char*>(&boot_node), sizeof(mkfs::hefs::BootNode));
+    output_device.seekp(static_cast<std::streamoff>(boot_node.startIND));
+    if (!output_device.good()) {
+        mkfs::console_out() << "hefs: error: Failed seek to startIND.\n";
+        return EXIT_FAILURE;
+    }
 
-  if (!output_device.good()) {
-    mkfs::console_out() << "hefs: error: Unable to write filesystem to output_device: "
-                        << output_path << "\n";
-    return EXIT_FAILURE;
-  }
+    output_device.flush();
+    output_device.close();
 
-  output_device.seekp(boot_node.startIND);
-
-  output_device.flush();
-  output_device.close();
-
-  mkfs::console_out() << "hefs: info: Wrote filesystem to output_device: " << output_path << "\n";
-
-  return EXIT_SUCCESS;
+    mkfs::console_out()
+        << "hefs: info: Wrote filesystem to output device: " << output_path << "\n";
+    return EXIT_SUCCESS;
 }


### PR DESCRIPTION
## Summary

Multiple unchecked inputs in `mkfs.hefs` let attackers overflow fixed‐size buffers and trigger undefined behavior. These issues together allow:

- Arbitrary writes past `volumeName`, leading to data corruption or code execution.

- Potential integer wrap or zero‐size disk creation, causing denial‐of‐service or further memory corruption.

The patch under review addresses each vulnerability with proper length checks, range checks, and safer parsing. Below, each flaw is described in detail, followed by the modifications and a proof‐of‐concept (PoC) demonstration. 

> **Date:** June 3, 2025

---

## Details

### 1. Buffer Overflow in Volume‐Label Copy
 
```c
// tooling/mkfs.hefs.cc (Vulnerable)

namespace mkfs::hefs {
    char16_t magic[16];         // must hold kHeFSMagicLen bytes (+NUL)
    char16_t volumeName[32];    // length = 32 UTF‐16 code units
};

...

// … after parsing kLabel (std::u8string built from argv) …

std::memcpy(
    boot_node.magic,
    kHeFSMagic,
    kHeFSMagicLen - 1
);

// No check that kLabel.size() ≤ 32 (the capacity of volumeName)!
std::memcpy(
    boot_node.volumeName,
    kLabel.data(),
    kLabel.size() * sizeof(char16_t)
);
```

- `kLabel` is constructed from the raw UTF-8 bytes of all `argv[i]` which can be arbitrarily large (40 code units or more), and each `char8_t` is cast directly into a `char16_t`without length checks.

- `volumeName[32]` can hold only 32 UTF-16 code units (64 bytes). If `kLabel.size() ≥ 32`, then `kLabel.size() * 2 bytes ≥ 64 bytes`, causing a write of 66–80+ bytes into a 64-byte buffer, overwriting adjacent fields in the `BootNode`struct.

```c
// tooling/mkfs.hefs.cc (Patched)

namespace mkfs::hefs {
    char16_t magic[16];         // must hold kHeFSMagicLen bytes (+NUL)
    char16_t volumeName[32];    // length = 32 UTF‐16 code units
};

...

// … after parsing kLabel (std::string built from argv) …

// 9. Copy 'magic' safely (shown later)…

// 10. Copy 'volumeName' safely (clamped to kHeFSPartNameLen = 32):
constexpr size_t vol_slots = kHeFSPartNameLen; // == 32
std::memset(boot_node.volumeName, 0, sizeof(boot_node.volumeName));

// Copy at most (vol_slots - 1) code units, leaving room for a NUL:
size_t label_units =
    (kLabel.size() < vol_slots - 1) ? kLabel.size() : (vol_slots - 1);

for (size_t i = 0; i < label_units; ++i) {
    // Naively cast each ASCII/UTF-8 byte to char16_t
    boot_node.volumeName[i] = static_cast<char16_t>(kLabel[i]);
}

// Explicitly terminate:
boot_node.volumeName[label_units] = 0;
```

---
### 2. Unsafe Copy of `magic[]`

```c
// tooling/mkfs.hefs.cc (Vulnerable)

std::memcpy(
    boot_node.magic,
    kHeFSMagic,
    kHeFSMagicLen - 1
);
```

This can silently overflow, there is no compile‐time assertion that `sizeof(boot_node.magic) ≥ kHeFSMagicLen`. meaning? a future change in the `kHeFSMagic` constant or `magic[]` array size can break this code without warning.

```c
// tooling/mkfs.hefs.cc (Patched)

// 9. Copy 'magic' safely:
static_assert(sizeof(boot_node.magic) >= kHeFSMagicLen,
              "BootNode::magic too small to hold kHeFSMagicLen");

std::memset(boot_node.magic, 0, sizeof(boot_node.magic));

size_t magic_copy =
    (sizeof(boot_node.magic) < kHeFSMagicLen - 1)
        ? sizeof(boot_node.magic)
        : (kHeFSMagicLen - 1);

std::memcpy(boot_node.magic, kHeFSMagic, magic_copy);

// Always leave one char16_t slot for NUL terminator:
boot_node.magic[magic_copy] = 0;
```

---
### 3. Arg Validation Gaps

```c
// tooling/mkfs.hefs.cc (Vulnerable)
// Flags read:
  -L  <label>
  -s  <sector_size>     (parsed with std::strtol(..., base=10))
  -b  <ind_start>       (parsed as hex, base=16)
  -e  <ind_end>         (hex)
  -bs <block_start>     (hex)
  -be <block_end>       (hex)
  -is <in_start>        (hex)
  -ie <in_end>          (hex)
  -S  <disk_size_GB>    (decimal, then multiplied by 1024*1024*1024)
  -o  <output_device>   (path)

// …later, the code does something like:
  auto output_path = mkfs::get_option<char>(args, "-o");

  kSectorSize = std::strtol(mkfs::get_option<char>(args, "-s").data(), nullptr, 10);
  kLabel      = mkfs::get_option<char8_t>(args_wide, u8"-L");

  if (!kSectorSize) {
    mkfs::console_out() << "hefs: error: Sector size size is set to zero.\n";
    return EXIT_FAILURE;
  }

  if (kLabel.empty()) kLabel = kHeFSDefaultVolumeName;

  kDiskSize =
      std::strtol(mkfs::get_option<char>(args, "-S").data(), nullptr, 10) * 1024 * 1024 * 1024;

  if (!kDiskSize) {
    mkfs::console_out() << "hefs: error: Disk size is set to zero.\n";
    return EXIT_FAILURE;
  }

  // Open the output_device
  std::ofstream output_device(output_path, std::ios::binary);

  if (!output_device.good()) {
    mkfs::console_out() << "hefs: error: Unable to open output_device: " << output_path << "\n";
    return EXIT_FAILURE;
  }

  // create a boot node, and then allocate a index node directory tree.
  mkfs::hefs::BootNode boot_node{{}, {}, 0, 0, 0, 0, 0, 0, 0, 0};

  auto start_ind = std::strtol(mkfs::get_option<char>(args, "-b").data(), nullptr, 16);

  start_ind += sizeof(mkfs::hefs::BootNode);

  auto end_ind = std::strtol(mkfs::get_option<char>(args, "-e").data(), nullptr, 16);

  auto start_block = std::strtol(mkfs::get_option<char>(args, "-bs").data(), nullptr, 16);
  auto end_block   = std::strtol(mkfs::get_option<char>(args, "-be").data(), nullptr, 16);

  auto start_in = std::strtol(mkfs::get_option<char>(args, "-is").data(), nullptr, 16);
  auto end_in   = std::strtol(mkfs::get_option<char>(args, "-ie").data(), nullptr, 16);

// No check whether each opt string was empty or invalid > silent 0.
// No check that end_* > start_* or that ranges fit within kDiskSize.
// No check of strtol return value to confirm valid number.
// kDiskSize multiplication can overflow.
```

If the user omits a required flag or supplies an empty string, `mkfs::get_option<char>(args, "-s")` returns `""`, so `.data()` points to a zero‐length `char*`. Passing `""` into `std::strtol( "", … )` returns `0` (no error‐check), so `kSectorSize = 0`. That triggers:

```c
    if (!kSectorSize) {
    }
```

But the same `std::strtol` call is used for `-S`, `-b`, and so on...  If _any_ of those is missing, you end up with `start_ind = 0 + sizeof(BootNode), or `end_ind = 0`, `start_block = 0`, `end_block = 0`

The code does not check that `end_ind > start_ind` or `end_block > start_block`, nor that those ranges fit within `kDiskSize`. That can easily lead to `seekp(0)`, or `seekp(0x0)` followed by a write at the wrong location, corrupting metadata or the file itself.

```c
// tooling/mkfs.hefs.cc (Patched)

// Power of two.
auto opt_s = mkfs::get_option<char>(args, "-s);
long parsed_s = 0;
if (!parse_signed(opt_s, parsed_s, 10) || parsed_s == 0) {
    mkfs::console_out()
        << "hefs: error: Invalid sector size \"" << opt_s
        << "\". Must be a positive integer.\n";
    return EXIT_FAILURE;
}
if ((parsed_s & (parsed_s - 1)) != 0) {
    mkfs::console_out()
        << "hefs: error: Sector size \"" << parsed_s
        << "\" is not a power of two.\n";
    return EXIT_FAILURE;
}
kSectorSize = static_cast<size_t>(parsed_s);

// If empty, convert default UTF-16 to ASCII:
auto opt_L = mkfs::get_option<char>(args, "-L");
if (!opt_L.empty()) {
    kLabel = opt_L;
} else {
    kLabel.clear();
    for (size_t i = 0; i < kHeFSPartNameLen && kHeFSDefaultVolumeName[i] != u'\0'; ++i) {
        kLabel.push_back(static_cast<char>(kHeFSDefaultVolumeName[i] & 0xFF));
    }
}

// Must be positive, no overflow.
auto opt_S = mkfs::get_option<char>(args, "-S");
unsigned long long gb = 0;
if (!parse_decimal(opt_S, gb) || gb == 0ULL) {
    mkfs::console_out()
        << "hefs: error: Invalid disk size \"" << opt_S
        << "\". Must be a positive integer.\n";
    return EXIT_FAILURE;
}
unsigned long long max_gb =
    std::numeric_limits<uint64_t>::max() / (1024ULL * 1024ULL * 1024ULL);
if (gb > max_gb) {
    mkfs::console_out()
        << "hefs: error: Disk size \"" << gb << "GB\" is too large.\n";
    return EXIT_FAILURE;
}
kDiskSize = static_cast<size_t>(gb * 1024ULL * 1024ULL * 1024ULL);

auto opt_b  = mkfs::get_option<char>(args, "-b");
auto opt_e  = mkfs::get_option<char>(args, "-e");
auto opt_bs = mkfs::get_option<char>(args, "-bs");
auto opt_be = mkfs::get_option<char>(args, "-be");
auto opt_is = mkfs::get_option<char>(args, "-is");
auto opt_ie = mkfs::get_option<char>(args, "-ie");

long start_ind   = 0, end_ind    = 0;
long start_block = 0, end_block  = 0;
long start_in    = 0, end_in     = 0;

if (!parse_signed(opt_b, start_ind, 16)) {
    mkfs::console_out() << "hefs: error: Invalid -b <hex> argument.\n";
    return EXIT_FAILURE;
}
if (!parse_signed(opt_e, end_ind, 16) || end_ind <= start_ind) {
    mkfs::console_out()
        << "hefs: error: Invalid or out-of-range -e <hex> argument.\n";
    return EXIT_FAILURE;
}
if (!parse_signed(opt_bs, start_block, 16)) {
    mkfs::console_out() << "hefs: error: Invalid -bs <hex> argument.\n";
    return EXIT_FAILURE;
}
if (!parse_signed(opt_be, end_block, 16) || end_block <= start_block) {
    mkfs::console_out()
        << "hefs: error: Invalid or out-of-range -be <hex> argument.\n";
    return EXIT_FAILURE;
}
if (!parse_signed(opt_is, start_in, 16)) {
    mkfs::console_out() << "hefs: error: Invalid -is <hex> argument.\n";
    return EXIT_FAILURE;
}
if (!parse_signed(opt_ie, end_in, 16) || end_in <= start_in) {
    mkfs::console_out()
        << "hefs: error: Invalid or out-of-range -ie <hex> argument.\n";
    return EXIT_FAILURE;
}

// Verify ranges do not exceed disk size:
if (static_cast<size_t>(end_block) * kSectorSize > kDiskSize ||
    static_cast<size_t>(end_ind)           > kDiskSize ||
    static_cast<size_t>(end_in)            > kDiskSize) {
    mkfs::console_out() << "hefs: error: One or more ranges exceed disk size.\n";
    return EXIT_FAILURE;
}
```

---
### 4. Integer‐Overflow When Computing `kDiskSize`

```c
// tooling/mkfs.hefs.cc (Vulnerable)

kDiskSize =
    std::strtol(mkfs::get_option<char>(args, "-S").data(), nullptr, 10)
    * 1024 * 1024 * 1024;

```

The problem here is, On a 32-bit `long` system, `std::strtol` returns a 32-bit signed long. If the user enters “2147483648” (which is 2³¹), `strtol` will wrap or saturate. Even on a 64-bit system, a user‐supplied “1,000,000,000” GB tries to allocate ~1 ZB of RAM, which cannot fit in a 64-bit `size_t` (2⁶⁴ – 1 bytes).

Signed multiplication can wrap around. That can lead to a very small `kDiskSize` (0 or a few KB), after which subsequent `seekp()` calls and writes become “out of range,” corrupting memory or the file layout.

```c
// tooling/mkfs.hefs.cc (Patched)

auto opt_S = mkfs::get_option<char>(args, "-S");
unsigned long long gb = 0;
if (!parse_decimal(opt_S, gb) || gb == 0ULL) {
    mkfs::console_out()
        << "hefs: error: Invalid disk size \"" << opt_S
        << "\". Must be a positive integer.\n";
    return EXIT_FAILURE;
}
// gb * (1024^3) fits in 64 bits
unsigned long long max_gb =
    std::numeric_limits<uint64_t>::max() / (1024ULL * 1024ULL * 1024ULL);
if (gb > max_gb) {
    mkfs::console_out()
        << "hefs: error: Disk size \"" << gb << "GB\" is too large.\n";
    return EXIT_FAILURE;
}
kDiskSize = static_cast<size_t>(gb * 1024ULL * 1024ULL * 1024ULL);

```

Parse into a 64-bit unsigned integer with range checks, Or, parse directly into `uint64_t` using `std::from_chars`

---
## PoC 

Below is a minimal PoC that overflows `volumeName[32]`:

```c
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <unistd.h>

#define OVERFLOW_SIZE 40   // > 32

int main(void) {
    // Build a 40-byte label of 'A's:
    char label[OVERFLOW_SIZE + 1];
    memset(label, 'A', OVERFLOW_SIZE);
    label[OVERFLOW_SIZE] = '\0';

    // Construct a cmd with an overlong label:
    char cmd[1024];
    snprintf(cmd, sizeof(cmd),
             "./mkfs.hefs "
             "-L \"%s\" "          
             "-s 512 "              
             "-b 0x1000 -e 0x8000 " 
             "-bs 0x8000 -be 0x800000 "
             "-is 0x800000 -ie 0xA00000 "
             "-S 128 "             
             "-o hefs.img",
             label);

    printf("Running: %s\n", cmd);
    int ret = system(cmd);
    if (ret != 0) {
        printf("mkfs.hefs returned non-zero (possible overflow triggered)\n");
    } else {
        printf("mkfs.hefs completed\n");
    }
    return 0;
}
```

1. On entry, `kLabel.size() == 40`.

2. `sizeof(char16_t) == 2`, so `memcpy(volumeName, kLabel.data(), 40 * 2)` writes 80 bytes. 

3. `volumeName[32]` buffers only 64 bytes. The extra 16 bytes overwrite `boot_node.indCount`, `diskStatus`, or subsequent fields.

4. When writing `sizeof(BootNode)` (which includes the corrupted fields) to disk, metadata becomes corrupted. If `BootNode` were on the stack in any other utility, the overflow could crash or lead to code execution.

---
## 4FutureDev & Notes

Patch any other “tooling/” binaries) for raw `memcpy` or `sprintf` calls without explicit length checks, and fuzz every user‐input path (flags, file content...) to detect corner cases, especially string‐copy and numeric‐conversion code. Before pushing in code enable compiler‐sanitizers so CI that any buffer overflow or integer wrap never goes unnoticed. 

Typically, `mkfs.hefs` must be run by a privileged user (root) to format a block device or write to raw files, An unprivileged user could format a file in their home directory, but cannot overwrite system disks.

>The primary impact is corruption overwriting adjacent fields in the `BootNode` struct on disk leads to either a malformed filesystem or potentially inconsistent reads/writes by other utilities, Even if limited to on‐disk corruption, an attacker could craft a disk image that later, when mounted, causes unpredictable behavior or DoS.

On a dedicated formatting utility, the worst‐case is local data corruption. If the attacker has no direct write access to the relevant device, the risk is lower, However, if a script or automation calls `mkfs.hefs` on any user‐submittable path, malformed flags could cause it to overwrite critical sectors (LBA 0) of the wrong device.