### PR TITLE
Patch: Buffer Overflows and OOB Reads in Core Memory APIs

### DIFF
--- a/dev/boot/src/BootSupport.cc
+++ b/dev/boot/src/BootSupport.cc
@@ -18,11 +18,16 @@
 /// @param dst destination pointer.
 /// @param byte value to fill in.
 /// @param len length of of src.
-EXTERN_C VoidPtr memset(void* dst, int byte, long long unsigned int len) {
-  for (size_t i = 0UL; i < len; ++i) {
-    ((int*) dst)[i] = byte;
+EXTERN_C VoidPtr memset(void* dst, int byte, long long unsigned int len, long long unsigned int dst_size) {
+  if (!dst || len > dst_size) {
+    // For now, we return nullptr or an error status.
+    return nullptr;
   }
-
+  unsigned char* p = (unsigned char*)dst; 
+  unsigned char val = (unsigned char)byte;
+  for (size_t i = 0UL; i < len; ++i) {
+    p[i] = val;
+  }
   return dst;
 }
 
@@ -30,36 +35,39 @@ EXTERN_C VoidPtr memset(void* dst, int byte, long long unsigned int len) {
 /// @param dst destination pointer.
 /// @param  src source pointer.
 /// @param len length of of src.
-EXTERN_C VoidPtr memcpy(void* dst, const void* src, long long unsigned int len) {
-  for (size_t i = 0UL; i < len; ++i) {
-    ((int*) dst)[i] = ((int*) src)[i];
+EXTERN_C VoidPtr memcpy(void* dst, const void* src, long long unsigned int len, long long unsigned int dst_size) {
+  if (!dst || !src || len > dst_size) {
+    // Similar to memset, this is a critical failure.
+    return nullptr;
   }
-
+  unsigned char* d = (unsigned char*)dst; 
+  const unsigned char* s = (const unsigned char*)src;
+  for (size_t i = 0UL; i < len; ++i) {
+    d[i] = s[i];
+  }
   return dst;
 }
 
 /// @brief strlen definition in C++.
-EXTERN_C size_t strlen(const char* whatToCheck) {
-  SizeT len = 0;
-
-  while (whatToCheck[len] != 0) {
+EXTERN_C size_t strlen(const char* whatToCheck, size_t max_len) {
+  size_t len = 0;
+  while (len < max_len && whatToCheck[len] != '\0') {
     ++len;
   }
-
   return len;
 }
 
 /// @brief strcmp definition in C++.
-EXTERN_C int strcmp(const char* whatToCheck, const char* whatToCheckRight) {
-  SizeT len = 0;
-
-  while (whatToCheck[len] == whatToCheckRight[len]) {
-    if (whatToCheck[len] == 0) return 0;
-
-    ++len;
+EXTERN_C int strcmp(const char* whatToCheck, const char* whatToCheckRight, size_t max_len) {
+  size_t i = 0;
+  while (i < max_len && whatToCheck[i] == whatToCheckRight[i]) {
+    if (whatToCheck[i] == '\0') return 0;
+    ++i;
   }
-
-  return len;
+  if (i == max_len) {
+    return 0;
+  }
+  return (unsigned char)whatToCheck[i] - (unsigned char)whatToCheckRight[i];
 }
 
 /// @brief something specific to the Microsoft's ABI, When the stack grows too big.


### PR DESCRIPTION
memset and memcpy now take an additional dst_size parameter, If len > dst_size or dst/src is null, the function returns nullptr early, avoiding unsafe writes. 